### PR TITLE
Iss909 - Restrict ability of ConditionsObjectProvider to one provided object

### DIFF
--- a/include/Conditions/SimpleCSVTableProvider.h
+++ b/include/Conditions/SimpleCSVTableProvider.h
@@ -10,46 +10,55 @@
 
 namespace ldmx {
 
-    /**
-     * @class ConditionsObjectProvider which can be configured to load conditions objects from
-     *  CSV files.
-     *
-     * Configuration via Python uses a parameter "provides" which is a list of elements each of which must contain
-     * "name","dataType", "columns", and "URL".  The parameter set _may_ contain "firstRun", "lastRun", and "runType".
-     * "DataType may be "int" or "double".  The "columns" parameter is the list of names of data columns to be read out.
-     * If "firstRun" is not provided, -1 is assumed.  If "lastRun" is not provided, -1 is assumed.
-     * The parameter "runType" could have the value "data", "MC", or "any".
-     * If "runType" is not provided, "any" is assumed.
-     * 
-     * In any URL, envrironment variables in the format ${VARNAME} will be expanded.  Also, the variable ${LDMX_CONDITION_TAG} will be replaced with the 
-     * tagname provided in the constructor.
-     */
-    class SimpleCSVTableProvider : public ConditionsObjectProvider {
-	public:
+/**
+ * @class ConditionsObjectProvider which can be configured to load conditions objects from
+ *  CSV files.
+ *
+ * Configuration via Python uses the following parameters:
+ * "dataType", "columns", "entries"
+ * "DataType may be "int" or "double".  
+ * The "columns" parameter is the list of names of data columns to be read out.
+
+ * "entries" is an array of parameter sets.
+ * Each entry must contain a "URL"
+ * The entry _may_ contain "firstRun", "lastRun", "runType", and "values".
+ * If "firstRun" is not provided, -1 is assumed.  If "lastRun" is not provided, -1 is assumed.
+ * The parameter "runType" could have the value "data", "MC", or "any".
+ * If "runType" is not provided, "any" is assumed.
+ * The parameter "values" is only used when the URL is "python:".  In this case, the value for each
+ * column will be taken from the values array and the configuration is expected to be independend of id.
+ * 
+ * In any URL, envrironment variables in the format ${VARNAME} will be expanded.  Also, the variable ${LDMX_CONDITION_TAG} will be replaced with the 
+ * tagname provided in the constructor.
+ */
+class SimpleCSVTableProvider : public ConditionsObjectProvider {
+ public:
 	
-	SimpleCSVTableProvider(const std::string& name, const std::string& tagname, const Parameters& parameters, Process& process);
+  SimpleCSVTableProvider(const std::string& name, const std::string& tagname, const Parameters& parameters, Process& process);
 
-	virtual ~SimpleCSVTableProvider();
+  virtual ~SimpleCSVTableProvider();
 
-	virtual std::pair<const ConditionsObject*,ConditionsIOV> getCondition(const std::string& condition_name, const EventHeader& context);
+  virtual std::pair<const ConditionsObject*,ConditionsIOV> getCondition(const EventHeader& context);
 
-        static void runTest(const std::string& host, const std::string& path, std::string& ss);
-	
-	private:
-	
-	struct Item {
-	    std::string objectName_;
-	    enum { OBJ_unknown, OBJ_int, OBJ_double } objectType_;
-	    ConditionsIOV iov_;
-	    std::string url_;
-	    std::vector<std::string> columns_;
-	};
-	std::vector<Item> items_;
+ private:
 
-	/** 
-	 * Utility for expanding environment variables
-	 */
-	std::string expandEnv(const std::string& s) const;
-    };
-}
+  enum { OBJ_unknown, OBJ_int, OBJ_double } objectType_;
+  std::vector<std::string> columns_;
+
+  struct Entry {
+    ConditionsIOV iov_;
+    std::string url_;
+    std::vector<int> ivalues_;
+    std::vector<double> dvalues_;
+  };
+
+  std::vector<Entry> entries_;
+
+  /** 
+   * Utility for expanding environment variables
+   */
+  std::string expandEnv(const std::string& s) const;
+};
+
+} // namespace ldmx
 #endif

--- a/include/Conditions/SimpleTableCondition.h
+++ b/include/Conditions/SimpleTableCondition.h
@@ -21,7 +21,7 @@ namespace ldmx {
 	
 	
 	/** Create table with given set of columns */
-	BaseTableCondition(const std::string& name, const std::vector<std::string>& columns) : ConditionsObject{name}, columns_{columns} {
+	BaseTableCondition(const std::string& name, const std::vector<std::string>& columns) : ConditionsObject{name}, columns_{columns},idMask_{0xFFFFFFFFu}  {
 	    columnCount_=(unsigned int)(columns.size());
 	}
 	
@@ -75,6 +75,21 @@ namespace ldmx {
 	    return keys_.size();
 	}
 
+
+        /**
+	 * Set an AND mask to be applied to the id.  Typically used to "flatten" a table in some manner.
+	 */
+	void setIdMask(unsigned int mask) { 
+	    idMask_=mask;
+	}
+
+	/**
+	 * Get the AND mask to be applied to the id.  Typically used to "flatten" a table in some manner.
+	 */
+	unsigned int getIdMask() const { 
+	    return idMask_;
+	}
+	    
 	protected:
 	
 	std::size_t findKey(unsigned int id) const;
@@ -84,6 +99,7 @@ namespace ldmx {
 	std::vector<std::string> columns_;
 	unsigned int columnCount_;
 	std::vector<uint32_t> keys_;
+        unsigned int idMask_;
     };
     
     template <class T>

--- a/python/SimpleCSVTableProvider.py
+++ b/python/SimpleCSVTableProvider.py
@@ -6,6 +6,20 @@ Specialization of ConditionsObjectProvider for simple tables indexed by detid
 from LDMX.Framework import ldmxcfg
 
 class SimpleCSVTableEntry:
+    """One entry in the providing table
+
+    This defines an "entry" in the table provider corresponding
+    to a certain Interval Of Validity (IOV). The entry can be
+    be valid between two run number, over all time, only for MC,
+    only for Data, or for both. The entry is retrieved from a
+    URL location.
+
+    Parameters
+    ----------
+    url : str
+        URL to download the table entry from
+    """
+
     def __init__(self, url):
         self.URL=url
         self.firstRun=-1
@@ -13,11 +27,21 @@ class SimpleCSVTableEntry:
         self.runType="any"
 
     def setIOV(self, firstRun, lastRun):
+        """Set the Interval Of Validity for this table entry
+
+        Parameters
+        ----------
+        firstRun : int
+            First run number that this entry is valid for
+        lastRun : int
+            Last run number that this entry is valid for
+        """
+
         self.firstRun=firstRun
         self.lastRun=lastRun
         
     def __str__(self) :
-        """Stringify this ConditionsObjectProvider, creates a message with all the internal parameters.
+        """Stringify this table entry
 
         Returns
         -------
@@ -25,42 +49,85 @@ class SimpleCSVTableEntry:
             A message with all the parameters and member variables in a human readable format
         """
 
-        msg = "\n  ConditionsObjectProvider(%s of class %s, tag='%s')"%(self.instanceName,self.className,self.tagName)
-        if len(self.__dict__)>0:
-            msg += "\n   Parameters:"
-            for k, v in self.__dict__.items():
-                msg += "\n    " + str(k) + " : " + str(v)
+        msg = "  TableEntry { "
+        if ( self.firstRun == -1 and self.lastRun == -1 ) :
+            msg += "Valid for All Time"
+        else :
+            msg += "Valid between %d and %d" %( self.firstRun , self.lastRun )
+
+        msg += ", Run Type %s, URL %s }" %( self.runType , self.URL )
 
         return msg 
 
 class SimpleCSVTableProvider(ldmxcfg.ConditionsObjectProvider):
+    """Provides a uniform table of a specific type
+
+    Parametrs
+    ---------
+    objName : str
+        Name of object that this provider provides (e.g. EcalGains)
+    tagName : str
+        Name of tag that this provider is generated from
+    dataType : str
+        Name of type of data stored in this table (e.g. "int" or "double")
+    columns : list of str
+        List of column names for this table
+    """
+
     def __init__(self,objName, tagName, dataType, columns):
-        super().__init__(objName,"ldmx::SimpleCSVTableProvider",tagName)
+        super().__init__(objName,"ldmx::SimpleCSVTableProvider",tagName,'Conditions')
         self.dataType=dataType
         self.columns=columns
         self.entries=[]
 
     def validForever(self, url):
+        """Add an entry to this provider that is valid forever and for all run types (data or MC)
+
+        Parameters
+        ----------
+        url : str
+            Location to download the table from
+        """
+
         self.entries.append(SimpleCSVTableEntry(url))
 
     def validForRuns(self, url, firstRun, lastRun):
+        """Add an entry to this provider that is valid between the input run numbers
+
+        Parameters
+        ----------
+        url : str
+            Location to download the table from
+        firstRun : int
+            First run number that this entry is valid for
+        lastRun : int
+            Last run number that this entry is valid for
+        """
+
         entry=SimpleCSVTableEntry(url)
         entry.setIOV(firstRun,lastRun)
         self.entries.append(entry)
 
     def validForAllRows(self, values):
+        """Define a value to use for all rows instead of downloading the table from a URL
+
+        Parameters
+        ----------
+        values : list
+            A value for each column to use for all rows
+        """
+
         entry=SimpleCSVTableEntry("python:")
         entry.values=values
         self.entries.append(entry)
         
 class SimpleCSVDoubleTableProvider(SimpleCSVTableProvider):
+    """Provider for tables of doubles"""
     def __init__(self,objName, tagName, columns):
         super().__init__(objName, tagName,"double",columns)
         
 class SimpleCSVIntegerTableProvider(SimpleCSVTableProvider):
+    """Provider for tables of integers"""
     def __init__(self,objName, tagName, columns):
         super().__init__(objName, tagName,"int",columns)
-
-    
-
 

--- a/python/SimpleCSVTableProvider.py
+++ b/python/SimpleCSVTableProvider.py
@@ -36,7 +36,7 @@ class SimpleCSVTableEntry:
 class SimpleCSVTableProvider(ldmxcfg.ConditionsObjectProvider):
     def __init__(self,objName, tagName, dataType, columns):
         super().__init__(objName,"ldmx::SimpleCSVTableProvider",tagName)
-        self.dataType="double"
+        self.dataType=dataType
         self.columns=columns
         self.entries=[]
 
@@ -47,6 +47,11 @@ class SimpleCSVTableProvider(ldmxcfg.ConditionsObjectProvider):
         entry=SimpleCSVTableEntry(url)
         entry.setIOV(firstRun,lastRun)
         self.entries.append(entry)
+
+    def validForAllRows(self, values):
+        entry=SimpleCSVTableEntry("python:")
+        entry.values=values
+        self.entries.append(entry)
         
 class SimpleCSVDoubleTableProvider(SimpleCSVTableProvider):
     def __init__(self,objName, tagName, columns):
@@ -56,6 +61,6 @@ class SimpleCSVIntegerTableProvider(SimpleCSVTableProvider):
     def __init__(self,objName, tagName, columns):
         super().__init__(objName, tagName,"int",columns)
 
-
+    
 
 

--- a/python/SimpleCSVTableProvider.py
+++ b/python/SimpleCSVTableProvider.py
@@ -5,13 +5,17 @@ Specialization of ConditionsObjectProvider for simple tables indexed by detid
 
 from LDMX.Framework import ldmxcfg
 
-class SimpleCSVTableItem:
-    def __init__(self, name, url, dataType, columns):
-        self.name=name
+class SimpleCSVTableEntry:
+    def __init__(self, url):
         self.URL=url
-        self.dataType=dataType;
-        self.columns=columns
+        self.firstRun=-1
+        self.lastRun=-1
+        self.runType="any"
 
+    def setIOV(self, firstRun, lastRun):
+        self.firstRun=firstRun
+        self.lastRun=lastRun
+        
     def __str__(self) :
         """Stringify this ConditionsObjectProvider, creates a message with all the internal parameters.
 
@@ -30,29 +34,28 @@ class SimpleCSVTableItem:
         return msg 
 
 class SimpleCSVTableProvider(ldmxcfg.ConditionsObjectProvider):
-    def __init__(self,instanceName, tagName):
-        super().__init__(instanceName,"ldmx::SimpleCSVTableProvider",tagName)
-        self.provides=[]
+    def __init__(self,objName, tagName, dataType, columns):
+        super().__init__(objName,"ldmx::SimpleCSVTableProvider",tagName)
+        self.dataType="double"
+        self.columns=columns
+        self.entries=[]
 
-    def provideIntegerTable(self, name, url, columns):
-        self.provides.append(SimpleCSVTableItem(name,url,"int",columns))
+    def validForever(self, url):
+        self.entries.append(SimpleCSVTableEntry(url))
 
-    def provideDoubleTable(self, name, url, columns):
-        self.provides.append(SimpleCSVTableItem(name,url,"double",columns))
+    def validForRuns(self, url, firstRun, lastRun):
+        entry=SimpleCSVTableEntry(url)
+        entry.setIOV(firstRun,lastRun)
+        self.entries.append(entry)
+        
+class SimpleCSVDoubleTableProvider(SimpleCSVTableProvider):
+    def __init__(self,objName, tagName, columns):
+        super().__init__(objName, tagName,"double",columns)
+        
+class SimpleCSVIntegerTableProvider(SimpleCSVTableProvider):
+    def __init__(self,objName, tagName, columns):
+        super().__init__(objName, tagName,"int",columns)
 
-    def __str__(self) :
-        """Stringify this ConditionsObjectProvider, creates a message with all the internal parameters.
 
-        Returns
-        -------
-        str
-            A message with all the parameters and member variables in a human readable format
-        """
 
-        msg = "\n  ConditionsObjectProvider(%s of class %s, tag='%s')"%(self.instanceName,self.className,self.tagName)
-        if len(self.__dict__)>0:
-            msg += "\n   Parameters:"
-            for k, v in self.__dict__.items():
-                msg += "\n    " + str(k) + " : " + str(v)
 
-        return msg

--- a/src/BaseTableCondition.cxx
+++ b/src/BaseTableCondition.cxx
@@ -4,13 +4,15 @@
 namespace ldmx {
     
     std::size_t BaseTableCondition::findKey(unsigned int id) const {
-	std::vector<unsigned int>::const_iterator ptr=std::lower_bound(keys_.begin(), keys_.end(), id);
-	if (ptr==keys_.end() || *ptr!=id) return keys_.size();
+        unsigned int effid=id&idMask_;
+	std::vector<unsigned int>::const_iterator ptr=std::lower_bound(keys_.begin(), keys_.end(), effid);
+	if (ptr==keys_.end() || *ptr!=effid) return keys_.size();
 	else return std::distance(keys_.begin(),ptr);
     }
     
     std::size_t BaseTableCondition::findKeyInsert(unsigned int id) const {
-	std::vector<unsigned int>::const_iterator ptr=std::lower_bound(keys_.begin(), keys_.end(), id);
+        unsigned int effid=id&idMask_;
+	std::vector<unsigned int>::const_iterator ptr=std::lower_bound(keys_.begin(), keys_.end(), effid);
 	return std::distance(keys_.begin(),ptr);
     }
 

--- a/src/SimpleCSVTableProvider.cxx
+++ b/src/SimpleCSVTableProvider.cxx
@@ -240,7 +240,7 @@ std::pair<const ConditionsObject*,ConditionsIOV> SimpleCSVTableProvider::getCond
           ldmx::utility::SimpleTableStreamerCSV::load(*table,ss);
           return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
         }
-      } else if (expurl.find("file://")!=std::string::npos || expurl.find("://")==std::string::npos) {
+      } else if (expurl.find("file://")!=std::string::npos || expurl.find(":")==std::string::npos) {
         std::string fname(expurl);
         if (expurl.find("file://")!=std::string::npos) fname=expurl.substr(expurl.find("file://")+strlen("file://"));
         std::ifstream fs(fname);

--- a/src/SimpleCSVTableProvider.cxx
+++ b/src/SimpleCSVTableProvider.cxx
@@ -9,157 +9,165 @@
 DECLARE_CONDITIONS_PROVIDER_NS(ldmx,SimpleCSVTableProvider);
 
 namespace ldmx {
-    SimpleCSVTableProvider::~SimpleCSVTableProvider() { }
+
+SimpleCSVTableProvider::~SimpleCSVTableProvider() { }
     
-    SimpleCSVTableProvider::SimpleCSVTableProvider(const std::string& name, const std::string& tagname, const Parameters& parameters, Process& process) :
-	ConditionsObjectProvider(name,tagname,parameters,process) {
+SimpleCSVTableProvider::SimpleCSVTableProvider(const std::string& name, const std::string& tagname, const Parameters& parameters, Process& process) :
+    ConditionsObjectProvider(name,tagname,parameters,process) {
 
-	if (parameters.exists("provides")) { // Pythonic
-	    std::vector<Parameters> plist=parameters.getParameter<std::vector<Parameters> > ("provides");
-	    for (auto aprov: plist) {
-		SimpleCSVTableProvider::Item item;
-		item.objectName_=aprov.getParameter<std::string>("name");
-		item.columns_=aprov.getParameter<std::vector<std::string>> ("columns");
-		int firstRun=aprov.getParameter<int>("firstRun",-1);
-		int lastRun=aprov.getParameter<int>("lastRun",-1);
-		std::string rtype=aprov.getParameter<std::string>("runType","any");
-		bool isMC=(rtype=="any" || rtype=="MC");
-		bool isData=(rtype=="any" || rtype=="data");
-		item.iov_=ConditionsIOV(firstRun,lastRun,isData,isMC);
-		item.url_=aprov.getParameter<std::string>("URL");
-		std::string dtype=aprov.getParameter<std::string>("dataType");
-		if (dtype=="int" || dtype=="integer") item.objectType_=SimpleCSVTableProvider::Item::OBJ_int;
-		if (dtype=="double" || dtype=="float") item.objectType_=SimpleCSVTableProvider::Item::OBJ_double;
-
-		// here we check for overlaps
-	
-		for (auto tabledef : items_) {
-		    if (tabledef.objectName_==item.objectName_ && item.iov_.overlaps(tabledef.iov_)) {
-			std::stringstream err;
-			err << "Table '" << tabledef.objectName_ << "' has entries with overlapping providers " << tabledef.url_ << " and " << item.url_;		   
-			EXCEPTION_RAISE("ConditionsException",err.str());
-		    }
-		}
-		// add to the list
-		items_.push_back(item);
-		if (std::find(objectNames_.begin(), objectNames_.end(), item.objectName_)==objectNames_.end()) objectNames_.push_back(item.objectName_);		
-	    }
-	}
-	if (parameters.exists("CSVprovides")) { // CSVs
-	}
+      
+  columns_=parameters.getParameter<std::vector<std::string>> ("columns");
+  std::string dtype=parameters.getParameter<std::string>("dataType");
+  if (dtype=="int" || dtype=="integer") objectType_=SimpleCSVTableProvider::OBJ_int;
+  if (dtype=="double" || dtype=="float") objectType_=SimpleCSVTableProvider::OBJ_double;
+      
+  std::vector<Parameters> plist=parameters.getParameter<std::vector<Parameters> > ("entries");
+  for (auto aprov: plist) {
+    SimpleCSVTableProvider::Entry item;
+    int firstRun=aprov.getParameter<int>("firstRun",-1);
+    int lastRun=aprov.getParameter<int>("lastRun",-1);
+    std::string rtype=aprov.getParameter<std::string>("runType","any");
+    bool isMC=(rtype=="any" || rtype=="MC");
+    bool isData=(rtype=="any" || rtype=="data");
+    item.iov_=ConditionsIOV(firstRun,lastRun,isData,isMC);
+    item.url_=aprov.getParameter<std::string>("URL");
+    if (objectType_==OBJ_int && aprov.exists("values")) {
+      item.ivalues_=aprov.getParameter<std::vector<int>>("values");
+      if (item.ivalues_.size()!=columns_.size()) {
+        EXCEPTION_RAISE("ConditionsException","Mismatch in values vector ("+std::to_string(item.ivalues_.size())+
+                        ") and columns vector ("+std::to_string(columns_.size())+") in "+getConditionObjectName());
+            
+      }
+    }        
+    if (objectType_==OBJ_double && aprov.exists("values")) {
+      item.dvalues_=aprov.getParameter<std::vector<double>>("values");
+      if (item.dvalues_.size()!=columns_.size()) {
+        EXCEPTION_RAISE("ConditionsException","Mismatch in values vector ("+std::to_string(item.dvalues_.size())+
+                        ") and columns vector ("+std::to_string(columns_.size())+") in "+getConditionObjectName());
+            
+      }
     }
+    // here we check for overlaps
+	
+    for (auto tabledef : entries_) {
+      if (item.iov_.overlaps(tabledef.iov_)) {
+        std::stringstream err;
+        err << "Table '" << getConditionObjectName() << "' has entries with overlapping providers " << tabledef.url_ << " and " << item.url_;		   
+        EXCEPTION_RAISE("ConditionsException",err.str());
+      }
+    }
+    // add to the list
+    entries_.push_back(item);
+  }
+}
 
 #define HACK_HACK
 #ifndef HACK_HACK
-    static void httpstream(const std::string& url, std::string& strbuf, int depth=0) {
-	using boost::asio::ip::tcp;
-	boost::asio::io_service io_service;
+static void httpstream(const std::string& url, std::string& strbuf, int depth=0) {
+  using boost::asio::ip::tcp;
+  boost::asio::io_service io_service;
 
-	int locslash=url.find("//");
-	std::string hostname=url.substr(locslash+2,url.find("/",locslash+2)-locslash-2);
-	std::string accessor=url.substr(0,locslash);
-
-	std::cout << accessor << std::endl;
+  int locslash=url.find("//");
+  std::string hostname=url.substr(locslash+2,url.find("/",locslash+2)-locslash-2);
 	
-	// Get a list of endpoints corresponding to the server name.
-	tcp::socket socket(io_service);
-	try {
-	    tcp::resolver resolver(io_service);
-	    tcp::resolver::query query(hostname, accessor);
-	    tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-	    
-	    // Try each endpoint until we successfully establish a connection.
-	    boost::asio::connect(socket, endpoint_iterator);
-	} catch (...) {
-	    EXCEPTION_RAISE("ConditionsException","Unable to access "+url+" to load conditions table.");
-	}
+  // Get a list of endpoints corresponding to the server name.
+  tcp::socket socket(io_service);
+  try {
+    tcp::resolver resolver(io_service);
+    tcp::resolver::query query(hostname, "http");
+    tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+    // Try each endpoint until we successfully establish a connection.
+    boost::asio::connect(socket, endpoint_iterator);
+  } catch (...) {
+    EXCEPTION_RAISE("ConditionsException","Unable to access "+url+" to load conditions table.");
+  }
 
-	// Form the request. We specify the "Connection: close" header so that the
-	// server will close the socket after transmitting the response. This will
-	// allow us to treat all data up until the EOF as the content.
-	boost::asio::streambuf request;
-	std::ostream request_stream(&request);
-	request_stream << "GET " << url << " HTTP/1.0\r\n";
-	request_stream << "Host: " << hostname << "\r\n";
-	request_stream << "Accept: */*\r\n";
-	request_stream << "Connection: close\r\n\r\n";
+  // Form the request. We specify the "Connection: close" header so that the
+  // server will close the socket after transmitting the response. This will
+  // allow us to treat all data up until the EOF as the content.
+  boost::asio::streambuf request;
+  std::ostream request_stream(&request);
+  request_stream << "GET " << url << " HTTP/1.0\r\n";
+  request_stream << "Host: " << hostname << "\r\n";
+  request_stream << "Accept: */*\r\n";
+  request_stream << "Connection: close\r\n\r\n";
 
-	// Send the request.
-	boost::asio::write(socket, request);
+  // Send the request.
+  boost::asio::write(socket, request);
 	
-	// Read the response status line. The response streambuf will automatically
-	// grow to accommodate the entire line. The growth may be limited by passing
-	// a maximum size to the streambuf constructor.
-	boost::asio::streambuf response;
-	boost::asio::read_until(socket, response, "\r\n");
+  // Read the response status line. The response streambuf will automatically
+  // grow to accommodate the entire line. The growth may be limited by passing
+  // a maximum size to the streambuf constructor.
+  boost::asio::streambuf response;
+  boost::asio::read_until(socket, response, "\r\n");
 	
-	// Check that response is OK.
-	std::istream response_stream(&response);
-	std::string http_version;
-	response_stream >> http_version;
-	unsigned int status_code;
-	response_stream >> status_code;
-	std::string status_message;
-	std::getline(response_stream, status_message);
-	if (!response_stream || http_version.substr(0, 5) != "HTTP/") {
-	    EXCEPTION_RAISE("ConditionsException","HTTP invalid response loading CSV file " + url + " from host " + hostname);
-	}
+  // Check that response is OK.
+  std::istream response_stream(&response);
+  std::string http_version;
+  response_stream >> http_version;
+  unsigned int status_code;
+  response_stream >> status_code;
+  std::string status_message;
+  std::getline(response_stream, status_message);
+  if (!response_stream || http_version.substr(0, 5) != "HTTP/") {
+    EXCEPTION_RAISE("ConditionsException","HTTP invalid response loading CSV file " + url + " from host " + hostname);
+  }
     
-	if (status_code >= 400) {
-	    EXCEPTION_RAISE("ConditionsException","HTTP status code " + std::to_string(status_code) + " loading CSV file " + url + " from host " + hostname);
-	}	
+  if (status_code >= 400) {
+    EXCEPTION_RAISE("ConditionsException","HTTP status code " + std::to_string(status_code) + " loading CSV file " + url + " from host " + hostname);
+  }	
 
-	if (status_code >= 300) { // redirect...
-	    // Read the response headers, which are terminated by a blank line.
-	    boost::asio::read_until(socket, response, "\r\n\r\n");
+  if (status_code >= 300) { // redirect...
+    // Read the response headers, which are terminated by a blank line.
+    boost::asio::read_until(socket, response, "\r\n\r\n");
 
-	    // Process the response headers.
-	    std::string header;
-	    std::string newurl;
-	    while (std::getline(response_stream, header) && header != "\r")
-		if (header.find("Location: ")!=std::string::npos)
-		    newurl=header.substr(10);
-	    if (newurl[newurl.size()-1]=='\r') newurl.erase(newurl.size()-1);		
+    // Process the response headers.
+    std::string header;
+    std::string newurl;
+    while (std::getline(response_stream, header) && header != "\r")
+      if (header.find("Location: ")!=std::string::npos)
+        newurl=header.substr(10);
+    if (newurl[newurl.size()-1]=='\r') newurl.erase(newurl.size()-1);		
 		
-	    //	    std::cout << "'" << newurl << "'\n";
+    //	    std::cout << "'" << newurl << "'\n";
 
-	    //	    std::cout << newurl << "," << newhost <<"\n";      
+    //	    std::cout << newurl << "," << newhost <<"\n";      
 					      
-	    // read to the end for good behavior
-	    boost::system::error_code error;
-	    while (boost::asio::read(socket, response,
-				     boost::asio::transfer_at_least(1), error));
-
-	    if (depth>20) {
-		EXCEPTION_RAISE("ConditionsException","Too much redirection in attempt to load HTTP CSV file");
-	    }
-            std::cout << newurl << " " << status_code << std::endl;
-	    httpstream(newurl,strbuf,depth+1); // recursion...
-	}
-
-	// Read until EOF, writing data to output as we go.
+<<<<<<< HEAD
+	// read to the end for good behavior
 	boost::system::error_code error;
-	bool storing=false;
 	while (boost::asio::read(socket, response,
-				 boost::asio::transfer_at_least(1), error));
+		   boost::asio::transfer_at_least(1), error));
 
-	while (response.size()>0) {
-	    std::string s;
-	    std::getline(response_stream, s);
-	    if (s.empty() || s=="\r") {
-		storing=true;
-		continue;
-	    }
-	    if (storing) {
-		strbuf+=s;
-		strbuf+='\n';
-	    }
-	}
-	
-	//	if (error != boost::asio::error::eof)
-	//   throw boost::system::system_error(error);
-	//	strbuf=build.str();
+    if (depth>10) {
+      EXCEPTION_RAISE("ConditionsException","Too much redirection in attempt to load HTTP CSV file");
     }
+    httpstream(newurl,strbuf,depth+1); // recursion...
+  }
+
+  // Read until EOF, writing data to output as we go.
+  boost::system::error_code error;
+  bool storing=false;
+  while (boost::asio::read(socket, response,
+                           boost::asio::transfer_at_least(1), error));
+
+  while (response.size()>0) {
+    std::string s;
+    std::getline(response_stream, s);
+    if (s.empty() || s=="\r") {
+      storing=true;
+      continue;
+    }
+    if (storing) {
+      strbuf+=s;
+      strbuf+='\n';
+    }
+  }
+	
+  //	if (error != boost::asio::error::eof)
+  //   throw boost::system::system_error(error);
+  //	strbuf=build.str();
+}
 #endif
 #ifdef HACK_HACK
   #include <sys/wait.h>
@@ -185,77 +193,86 @@ static void httpstream(const std::string& url, std::string& strbuf, int depth=0)
 
 #endif
 
-
-    std::string SimpleCSVTableProvider::expandEnv(const std::string& s) const {
-	std::string retval;
-	std::string::size_type j=0;
-	for (std::string::size_type i=s.find("${",j); i<s.size(); i=s.find("${",j)) {
-	    if (i!=j) retval.append(s,j,i-j); // append
-	    j=s.find("}",i); // look for the end of request
-	    std::string key=std::string(s,i+2,j-i-2);
-	    if (key=="LDMX_CONDITION_TAG") retval+=getTagName();
-	    else {
-		const char* cenv=getenv(key.c_str());
-		if (cenv!=0) {
-		    retval+=cenv;
-		}
-		else {
-		    // ERROR!
-		}
-	    }
-	    j++;	    
-	}
-	if (j<s.size()) retval.append(s,j);
-	//	std::cout << s << "=>" << retval << std::endl;
-	return retval;
+std::string SimpleCSVTableProvider::expandEnv(const std::string& s) const {
+  std::string retval;
+  std::string::size_type j=0;
+  for (std::string::size_type i=s.find("${",j); i<s.size(); i=s.find("${",j)) {
+    if (i!=j) retval.append(s,j,i-j); // append
+    j=s.find("}",i); // look for the end of request
+    std::string key=std::string(s,i+2,j-i-2);
+    if (key=="LDMX_CONDITION_TAG") retval+=getTagName();
+    else {
+      const char* cenv=getenv(key.c_str());
+      if (cenv!=0) {
+        retval+=cenv;
+      }
+      else {
+        // ERROR!
+      }
     }
+    j++;	    
+  }
+  if (j<s.size()) retval.append(s,j);
+  //	std::cout << s << "=>" << retval << std::endl;
+  return retval;
+}
 
-    std::pair<const ConditionsObject*,ConditionsIOV> SimpleCSVTableProvider::getCondition(const std::string& condition_name, const EventHeader& context) {
-	// put the condition tag into the environment for wordexp to use
-	setenv("LDMX_CONDITION_TAG",getTagName().c_str(),1);
+std::pair<const ConditionsObject*,ConditionsIOV> SimpleCSVTableProvider::getCondition(const EventHeader& context) {
+  // put the condition tag into the environment for wordexp to use
+  setenv("LDMX_CONDITION_TAG",getTagName().c_str(),1);
 
-	for (auto tabledef : items_) {
-	    //	    std::cout << condition_name << " " << tabledef.objectName_ << " " << tabledef.iov_ << " " << std::endl;
-	    if (condition_name == tabledef.objectName_ && tabledef.iov_.validForEvent(context)) {
-		std::string expurl=expandEnv(tabledef.url_);
-		//		std::cout << "url:" <<  expurl << " from " << tabledef.url_ << std::endl;
-		if (expurl.find("http://")!=std::string::npos || expurl.find("https://")!=std::string::npos) {
-		    std::string buffer;
-		    httpstream(expurl,buffer);
-		    //std::cout <<buffer <<std::endl;
-		    std::stringstream ss(buffer);
-		    if (tabledef.objectType_==Item::OBJ_int) {
-			IntegerTableCondition* table=new IntegerTableCondition(tabledef.objectName_,tabledef.columns_);
-			ldmx::utility::SimpleTableStreamerCSV::load(*table,ss);
-			return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
-		    } else if (tabledef.objectType_==Item::OBJ_double) {
-			DoubleTableCondition* table=new DoubleTableCondition(tabledef.objectName_,tabledef.columns_);
-			ldmx::utility::SimpleTableStreamerCSV::load(*table,ss);
-			return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
-		    }
-		} else if (expurl.find("file://")!=std::string::npos || expurl.find("://")==std::string::npos) {
-		    std::string fname(expurl);
-		    if (expurl.find("file://")!=std::string::npos) fname=expurl.substr(expurl.find("file://")+strlen("file://"));
-		    std::ifstream fs(fname);
-		    if (!fs.good()) {
-			EXCEPTION_RAISE("ConditionsException","Unable to open CSV file '"+fname+"'");
-		    }
-		    if (tabledef.objectType_==Item::OBJ_int) {
-			IntegerTableCondition* table=new IntegerTableCondition(tabledef.objectName_,tabledef.columns_);
-			ldmx::utility::SimpleTableStreamerCSV::load(*table,fs);
-			return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
-		    } else if (tabledef.objectType_==Item::OBJ_double) {
-			DoubleTableCondition* table=new DoubleTableCondition(tabledef.objectName_,tabledef.columns_);
-			ldmx::utility::SimpleTableStreamerCSV::load(*table,fs);
-			return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
-		    }
-		}			
-	    }
-	}
-	return std::pair<const ConditionsObject*,ConditionsIOV>(0,ConditionsIOV());
+  for (auto tabledef : entries_) {
+    //	    std::cout << condition_name << " " << tabledef.objectName_ << " " << tabledef.iov_ << " " << std::endl;
+    if (tabledef.iov_.validForEvent(context)) {
+      std::string expurl=expandEnv(tabledef.url_);
+      //		std::cout << "url:" <<  expurl << " from " << tabledef.url_ << std::endl;
+      if (expurl.find("http://")!=std::string::npos) {
+        std::string buffer;
+        httpstream(expurl,buffer);
+        //std::cout <<buffer <<std::endl;
+        std::stringstream ss(buffer);
+        if (objectType_==OBJ_int) {
+          IntegerTableCondition* table=new IntegerTableCondition(getConditionObjectName(),columns_);
+          ldmx::utility::SimpleTableStreamerCSV::load(*table,ss);
+          return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
+        } else if (objectType_==OBJ_double) {
+          DoubleTableCondition* table=new DoubleTableCondition(getConditionObjectName(),columns_);
+          ldmx::utility::SimpleTableStreamerCSV::load(*table,ss);
+          return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
+        }
+      } else if (expurl.find("file://")!=std::string::npos || expurl.find("://")==std::string::npos) {
+        std::string fname(expurl);
+        if (expurl.find("file://")!=std::string::npos) fname=expurl.substr(expurl.find("file://")+strlen("file://"));
+        std::ifstream fs(fname);
+        if (!fs.good()) {
+          EXCEPTION_RAISE("ConditionsException","Unable to open CSV file '"+fname+"'");
+        }
+        if (objectType_==OBJ_int) {
+          IntegerTableCondition* table=new IntegerTableCondition(getConditionObjectName(),columns_);
+          ldmx::utility::SimpleTableStreamerCSV::load(*table,fs);
+          return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
+        } else if (objectType_==OBJ_double) {
+          DoubleTableCondition* table=new DoubleTableCondition(getConditionObjectName(),columns_);
+          ldmx::utility::SimpleTableStreamerCSV::load(*table,fs);
+          return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
+        }
+      } else if (expurl=="python:") {
+        // here we just copy values...
+        if (objectType_==OBJ_int) {
+          IntegerTableCondition* table=new IntegerTableCondition(getConditionObjectName(),columns_);
+          table->setIdMask(0); // all ids are the same...
+          table->add(0,tabledef.ivalues_);
+          return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
+        } else if (objectType_==OBJ_double) {
+          DoubleTableCondition* table=new DoubleTableCondition(getConditionObjectName(),columns_);
+          table->setIdMask(0); // all ids are the same...
+          table->add(0,tabledef.dvalues_);
+          return std::pair<const ConditionsObject*,ConditionsIOV>(table,tabledef.iov_);
+        }
+      }
     }
+  }
+  return std::pair<const ConditionsObject*,ConditionsIOV>(0,ConditionsIOV());
+}
     
-    void SimpleCSVTableProvider::runTest(const std::string& host, const std::string& path, std::string& ss) {
-
-    }
 }

--- a/test/TestConditions.cxx
+++ b/test/TestConditions.cxx
@@ -144,7 +144,7 @@ namespace ldmx {
             }
 
             SECTION( "Testing python static" ) {
-              const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process(\"test\")\np.testMode=True\ncolumns=[\"A\",\"B\",\"C\"]\ncop=SimpleCSVTableProvider.SimpleCSVIntegerTableProvider(\"test_table_python\",\"TEST_MODE\",columns)\ncop.validForAllRows([10,45,129])\np.declareConditionsObjectProvider(cop)\np.libraries.append(\"libConditions.so\")\n";
+              const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process('test')\np.testMode=True\ncolumns=['A','B','C']\ncop=SimpleCSVTableProvider.SimpleCSVIntegerTableProvider('test_table_python','TEST_MODE',columns)\ncop.validForAllRows([10,45,129])";
 
               FILE* f=fopen("/tmp/test_cond.py","w");
               fputs(cfg,f);
@@ -171,7 +171,7 @@ namespace ldmx {
                 fs.close();
                 //	std::cout << "Step 1" << std::endl << ss.str();
 
-                const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process(\"test\")\np.testMode=True\ncolumns=[\"SQRT\",\"EXP\",\"LOG\"]\ncop=SimpleCSVTableProvider.SimpleCSVDoubleTableProvider(\"test_table_file\",\"TEST_MODE\",columns)\ncop.validForRuns(\"file:///tmp/dump_double.csv\",0,100)\ncop.validForRuns(\"/tmp/dump_double.csv\",101,120)\np.declareConditionsObjectProvider(cop)\np.libraries.append(\"libConditions.so\")\n";
+                const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process('test')\np.testMode=True\ncolumns=['SQRT','EXP','LOG']\ncop=SimpleCSVTableProvider.SimpleCSVDoubleTableProvider('test_table_file','TEST_MODE',columns)\ncop.validForRuns('file:///tmp/dump_double.csv',0,100)\ncop.validForRuns('/tmp/dump_double.csv',101,120)\n";
 
                 FILE* f=fopen("/tmp/test_cond.py","w");
                 fputs(cfg,f);

--- a/test/TestConditions.cxx
+++ b/test/TestConditions.cxx
@@ -151,7 +151,7 @@ namespace ldmx {
                 fs.close();
                 //	std::cout << "Step 1" << std::endl << ss.str();
 
-                const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process(\"test\")\np.testMode=True\ncolumns=[\"SQRT\",\"EXP\",\"LOG\"]\ncop=SimpleCSVTableProvider.SimpleCSVTableProvider(\"tableSource\",\"TEST_MODE\")\ncop.provideDoubleTable(\"test_table_file1\",\"file:///tmp/dump_double.csv\",columns)\ncop.provideDoubleTable(\"test_table_file2\",\"/tmp/dump_double.csv\",columns)\np.declareConditionsObjectProvider(cop)\np.libraries.append(\"libConditions.so\")\n";
+                const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process(\"test\")\np.testMode=True\ncolumns=[\"SQRT\",\"EXP\",\"LOG\"]\ncop=SimpleCSVTableProvider.SimpleCSVDoubleTableProvider(\"test_table_file\",\"TEST_MODE\",columns)\ncop.validForRuns(\"file:///tmp/dump_double.csv\",0,100)\ncop.validForRuns(\"/tmp/dump_double.csv\",101,120)\np.declareConditionsObjectProvider(cop)\np.libraries.append(\"libConditions.so\")\n";
 
                 FILE* f=fopen("/tmp/test_cond.py","w");
                 fputs(cfg,f);
@@ -160,16 +160,18 @@ namespace ldmx {
                 ldmx::ConfigurePython cp("/tmp/test_cond.py",0,0);
                 ldmx::ProcessHandle hp=cp.makeProcess();
                 EventHeader cxt;
+                hp->setEventHeader(&cxt);
 
-                const DoubleTableCondition& fTable1=hp->getConditions().getCondition<DoubleTableCondition>("test_table_file1",cxt);
-                const DoubleTableCondition& fTable2=hp->getConditions().getCondition<DoubleTableCondition>("test_table_file2",cxt);
+                cxt.setRun(10);
+                const DoubleTableCondition& fTable1=hp->getConditions().getCondition<DoubleTableCondition>("test_table_file");
+                cxt.setRun(119);
+                const DoubleTableCondition& fTable2=hp->getConditions().getCondition<DoubleTableCondition>("test_table_file");
                 matchesAll(dtable,fTable1);
                 matchesAll(dtable,fTable2);
             }
-
             /*
             SECTION( "Testing HTTP loading" ) {
-                const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process(\"test\")\np.testMode=True\ncolumns=[\"A\",\"Q\",\"V\"]\ncop=SimpleCSVTableProvider.SimpleCSVTableProvider(\"tableSource\",\"TEST_MODE\")\ncop.provideIntegerTable(\"test_table_http\",\"https://homepages.spa.umn.edu/~jmmans/test_table.csv\",columns)\np.declareConditionsObjectProvider(cop)\np.libraries.append(\"libConditions.so\")\n";
+                const char* cfg="#!/usr/bin/python\n\nimport sys\n\nfrom LDMX.Framework import ldmxcfg\nfrom LDMX.Conditions import SimpleCSVTableProvider\n\np=ldmxcfg.Process(\"test\")\np.testMode=True\ncolumns=[\"A\",\"Q\",\"V\"]\ncop=SimpleCSVTableProvider.SimpleCSVDoubleTableProvider(\"test_table_http\",\"TEST_MODE\",columns)\ncop.validForever(\"http://webusers.physics.umn.edu/~jmmans/test_table.csv\")\n";
 
                 FILE* f=fopen("/tmp/test_cond.py","w");
                 fputs(cfg,f);
@@ -178,8 +180,9 @@ namespace ldmx {
                 ldmx::ConfigurePython cp("/tmp/test_cond.py",0,0);
                 ldmx::ProcessHandle hp=cp.makeProcess();
                 EventHeader cxt;
-
-                const IntegerTableCondition& httpTable=hp->getConditions().getCondition<IntegerTableCondition>("test_table_http",cxt);
+                hp->setEventHeader(&cxt);
+                
+                const IntegerTableCondition& httpTable=hp->getConditions().getCondition<IntegerTableCondition>("test_table_http");
                 matchesAll(httpTable,itable);
             }
             */


### PR DESCRIPTION
This restriction makes configuring the conditions object providers a lot simpler because they map one-to-one to a provided conditions object.