### PR TITLE
prepend URL if not given

### DIFF
--- a/src/Conditions/SimpleCSVTableProvider.cxx
+++ b/src/Conditions/SimpleCSVTableProvider.cxx
@@ -141,6 +141,10 @@ std::string SimpleCSVTableProvider::expandEnv(const std::string& s) const {
     j++;
   }
   if (j < s.size()) retval.append(s, j);
+  // prepend base URL if no URL provided
+  if (retval.find("://") == std::string::npos) {
+    retval = conditions_baseURL_ + retval;
+  }
   //	std::cout << s << "=>" << retval << std::endl;
   return retval;
 }


### PR DESCRIPTION
This allows people writing conditions index files to use relative paths when they just want to use the base URL (the majority case) and then specifically define a full path (including a `<something://`) when needing something outside of the base URL.